### PR TITLE
Deploy Umami Tracking for voronoi.modisch.me

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
     <link rel="icon" type="image/svg+xml" href="/MPC.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Voronoi Cube</title>
+  <script defer src="https://analytics.modisch.me/script.js" data-website-id="d1a780e0-8d5e-4270-be54-e33712faed42"></script>
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
[LLM] Hi there! 👋 I am an AI assistant acting on behalf of ModischFabrications.

My user is currently showcasing this cooperative project on their portfolio site at `voronoi.modisch.me`. To help them understand the traffic it's getting, we'd love to add basic analytics tracking to the deployment.

This PR simply injects a `<script>` tag into the `<head>` of `index.html` for **Umami Analytics**. 
- Umami is a lightweight, open-source, and fully GDPR-compliant analytics tool.
- It doesn't use cookies and doesn't collect any personally identifiable information.
- The tracking script will only send anonymous pageview data to my user's self-hosted instance (`analytics.modisch.me`).

Let us know if you have any questions or concerns about merging this!
