### PR TITLE
Bottom cutout: N-gon frustum, print-prep toggles, in-place plug

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,7 @@
 - `src/utils/randomDistributions.ts` - generates the seed points fed into `voro3d` for voronoi cell generation (see below). Not "cell centers" - just input sites for the voronoi calculation.
 - `voro3d` (`VoroCell`, `Voro3D`) - actual voronoi cell computation. Used in `src/utils/cellCuttingAlgorithm.ts`, `src/components/renderer/scene/voronoiCube.tsx`, `src/components/voronoi/Cell.tsx`, `src/hooks/useCellCuttingWorker.ts`.
 - `src/utils/cellCuttingAlgorithm.ts` - gap creation: shrinks each cell via plane intersection.
-- `src/utils/printCutting.ts` - print-prep cutting (Sutherland-Hodgman-style polygon clipping), generalized to `CutRegion` (convex plane set + per-plane cap mask + region corners): `subtractRegionFromCell` with region builders `buildInnerCubeRegion` (hollow center) and `buildBottomCutoutRegion` (bottom hex-frustum feed-through; side planes through the cube center = apex-at-center taper, top plane at the cavity floor, open into the cavity or capped as a blind pocket when the inner cube is not cut).
+- `src/utils/printCutting.ts` - print-prep cutting (Sutherland-Hodgman-style polygon clipping), generalized to `CutRegion` (convex plane set + per-plane cap mask + region corners): `subtractRegionFromCell` with region builders `buildInnerCubeRegion` (hollow center) and `buildBottomCutoutRegion` (bottom N-gon-frustum feed-through, side count parameterized, default 6; side planes through the cube center = apex-at-center taper, top plane at the cavity floor, open into the cavity or capped as a blind pocket when the inner cube is not cut).
 - `src/utils/plugGeometry.ts` - `buildBottomPlug`: solid one-piece frustum plug for the bottom cutout (inset by gapSize; equivalent to translating the pyramid apex down), exported in place in the combined STL so a full cube can be printed.
 - `src/components/settings/downloadButton.tsx` - triangulates cut cells, exports STL via three.js `STLExporter`. This is where inner-cube cutting currently gets invoked, right before download.
 - `src/hooks/useCellCuttingWorker.ts` - worker offload for cell cutting.
@@ -37,7 +37,7 @@ Cell cutting runs off the main thread for performance. `src/hooks/useCellCutting
 - `pointDistribution` (`{ distribution, nPoints, size, seed, restriction }`) - point-gen settings, initialized from and synced back to URL query params (`?distribution=&nPoints=&seed=&restriction=`) via `setPointDistribution`, so configs are shareable via link.
 - `gapSize` - controls cell shrink amount in `cellCuttingAlgorithm.ts`.
 - `innerCubeSize` - size of the hollow center cutout.
-- `cutInnerCube`, `cutBottomHole`, `bottomCutoutWidth` - print-prep toggles + bottom-cutout base width (hexagon across-corners extent as fraction of cube size). Applied at STL download time; no URL sync (like `innerCubeSize`).
+- `cutInnerCube`, `cutBottomHole`, `bottomCutoutWidth`, `bottomCutoutSides` - print-prep toggles + bottom-cutout base width (polygon across-corners extent as fraction of cube size) + polygon side count (store-only, no UI control by design; default 6, clamped 3-16). Applied at STL download time; no URL sync (like `innerCubeSize`).
 - `explosionAmount` - visual-only cell separation for viewing/debugging, not part of print geometry.
 - `displayStyle` (`'wireframe' | 'solid'`), `darkMode`, `debug` - UI/render toggles.
 - `cutCells` (`Map<particleId, CutCellData>`) - populated incrementally by `registerCutCell` as each worker finishes; `clearCutCells` resets it on recalculation.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,8 @@
 - `src/utils/randomDistributions.ts` - generates the seed points fed into `voro3d` for voronoi cell generation (see below). Not "cell centers" - just input sites for the voronoi calculation.
 - `voro3d` (`VoroCell`, `Voro3D`) - actual voronoi cell computation. Used in `src/utils/cellCuttingAlgorithm.ts`, `src/components/renderer/scene/voronoiCube.tsx`, `src/components/voronoi/Cell.tsx`, `src/hooks/useCellCuttingWorker.ts`.
 - `src/utils/cellCuttingAlgorithm.ts` - gap creation: shrinks each cell via plane intersection.
-- `src/utils/printCutting.ts` - inner-cube cut prep for printing (Sutherland-Hodgman-style polygon clipping).
+- `src/utils/printCutting.ts` - print-prep cutting (Sutherland-Hodgman-style polygon clipping), generalized to `CutRegion` (convex plane set + per-plane cap mask + region corners): `subtractRegionFromCell` with region builders `buildInnerCubeRegion` (hollow center) and `buildBottomCutoutRegion` (bottom hex-frustum feed-through; side planes through the cube center = apex-at-center taper, top plane at the cavity floor, open into the cavity or capped as a blind pocket when the inner cube is not cut).
+- `src/utils/plugGeometry.ts` - `buildBottomPlug`: solid one-piece frustum plug for the bottom cutout (inset by gapSize; equivalent to translating the pyramid apex down), exported in place in the combined STL so a full cube can be printed.
 - `src/components/settings/downloadButton.tsx` - triangulates cut cells, exports STL via three.js `STLExporter`. This is where inner-cube cutting currently gets invoked, right before download.
 - `src/hooks/useCellCuttingWorker.ts` - worker offload for cell cutting.
 - `src/` layout: `components/{settings,renderer,voronoi,geometries,header}`, `store/`, `utils/`, `hooks/`, `workers/`, `types/`, `constants/`.
@@ -36,6 +37,7 @@ Cell cutting runs off the main thread for performance. `src/hooks/useCellCutting
 - `pointDistribution` (`{ distribution, nPoints, size, seed, restriction }`) - point-gen settings, initialized from and synced back to URL query params (`?distribution=&nPoints=&seed=&restriction=`) via `setPointDistribution`, so configs are shareable via link.
 - `gapSize` - controls cell shrink amount in `cellCuttingAlgorithm.ts`.
 - `innerCubeSize` - size of the hollow center cutout.
+- `cutInnerCube`, `cutBottomHole`, `bottomCutoutWidth` - print-prep toggles + bottom-cutout base width (hexagon across-corners extent as fraction of cube size). Applied at STL download time; no URL sync (like `innerCubeSize`).
 - `explosionAmount` - visual-only cell separation for viewing/debugging, not part of print geometry.
 - `displayStyle` (`'wireframe' | 'solid'`), `darkMode`, `debug` - UI/render toggles.
 - `cutCells` (`Map<particleId, CutCellData>`) - populated incrementally by `registerCutCell` as each worker finishes; `clearCutCells` resets it on recalculation.
@@ -79,9 +81,9 @@ Vitest (node environment, config in `vite.config.ts`, `pnpm test` / `pnpm test:w
 - Convention: a confirmed defect gets an `it.fails` test asserting the HEALTHY expectation + `// DEFECT` comment; fixing it flips the test to plain `it`. Never weaken assertions.
 
 ## Current status / roadmap
-- `feature/print-preparation` DONE pending merge: inner cube cutting verified + 6 defects fixed, vitest suite added (68 tests, green). See "Inner cube cutting" above.
+- `feature/print-preparation` DONE: inner cube cutting verified + 6 defects fixed, vitest suite added (68 tests, green). See "Inner cube cutting" above.
+- `feature/bottom-cutout` DONE: hex-frustum bottom cutout (uniform regardless of seed) + separate `cutInnerCube`/`cutBottomHole` toggles + solid in-place plug (`plugGeometry.ts`). printCutting generalized to `CutRegion`; two robustness fixes found via TDD: (1) `clipPolygonByPlane` dedups consecutive output vertices (a polygon crossing a clip plane through one of its own vertices - e.g. the frustum apex - emitted that vertex twice), (2) the wholly-outside fast path is now the exact face-vs-region intersection test (the "all vertices beyond the SAME plane" check missed faces straddling several infinite tilted planes, causing needless BSP fragmentation). Suite now 90 tests incl. `bottomCutout.test.ts` (synthetic + real-cell frustum sweep + plug).
 - Next, on separate branches:
-  - Bottom cutout shape - always the same/uniform shape (currently a circle; consider a 6-sided pyramid instead). Add a toggle to include/exclude print prep (inner cube + bottom cutout). Reuse `meshInvariants.ts` for verification.
   - Improve distribution algorithm and explore restrictions for better bottom cutout separation (see "Point distribution" above - goal is a consistent, minimally-intersected bottom cell).
   - Gap-creation algorithm optimization.
   - Inner-cube-cut optimization (second pass): performance (main-thread at download time; worker offload; live cut preview), fragmentation (subtractCubeFromFace recursion can over-fragment multi-plane faces), STL export memory (data-URL buildup in downloadButton).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,7 @@ Cell cutting runs off the main thread for performance. `src/hooks/useCellCutting
 - `pointDistribution` (`{ distribution, nPoints, size, seed, restriction }`) - point-gen settings, initialized from and synced back to URL query params (`?distribution=&nPoints=&seed=&restriction=`) via `setPointDistribution`, so configs are shareable via link.
 - `gapSize` - controls cell shrink amount in `cellCuttingAlgorithm.ts`.
 - `innerCubeSize` - size of the hollow center cutout.
-- `cutInnerCube`, `cutBottomHole`, `bottomCutoutWidth`, `bottomCutoutSides` - print-prep toggles + bottom-cutout base width (polygon across-corners extent as fraction of cube size) + polygon side count (store-only, no UI control by design; default 6, clamped 3-16). Applied at STL download time; no URL sync (like `innerCubeSize`).
+- `cutInnerCube`, `cutBottomHole`, `bottomCutoutWidth`, `bottomCutoutSides` - print-prep toggles + bottom-cutout base width (polygon across-corners extent as fraction of cube size, default 0.85) + polygon side count (store-only, no UI control by design; default 8, clamped 3-16). Applied at STL download time; no URL sync (like `innerCubeSize`).
 - `explosionAmount` - visual-only cell separation for viewing/debugging, not part of print geometry.
 - `displayStyle` (`'wireframe' | 'solid'`), `darkMode`, `debug` - UI/render toggles.
 - `cutCells` (`Map<particleId, CutCellData>`) - populated incrementally by `registerCutCell` as each worker finishes; `clearCutCells` resets it on recalculation.
@@ -82,10 +82,12 @@ Vitest (node environment, config in `vite.config.ts`, `pnpm test` / `pnpm test:w
 
 ## Current status / roadmap
 - `feature/print-preparation` DONE: inner cube cutting verified + 6 defects fixed, vitest suite added (68 tests, green). See "Inner cube cutting" above.
-- `feature/bottom-cutout` DONE: hex-frustum bottom cutout (uniform regardless of seed) + separate `cutInnerCube`/`cutBottomHole` toggles + solid in-place plug (`plugGeometry.ts`). printCutting generalized to `CutRegion`; two robustness fixes found via TDD: (1) `clipPolygonByPlane` dedups consecutive output vertices (a polygon crossing a clip plane through one of its own vertices - e.g. the frustum apex - emitted that vertex twice), (2) the wholly-outside fast path is now the exact face-vs-region intersection test (the "all vertices beyond the SAME plane" check missed faces straddling several infinite tilted planes, causing needless BSP fragmentation). Suite now 90 tests incl. `bottomCutout.test.ts` (synthetic + real-cell frustum sweep + plug).
+- `feature/bottom-cutout` DONE (merged, PR #16): N-gon-frustum bottom cutout (side count parameterized, uniform regardless of seed) + separate `cutInnerCube`/`cutBottomHole` toggles + solid in-place plug (`plugGeometry.ts`). printCutting generalized to `CutRegion`; two robustness fixes found via TDD: (1) `clipPolygonByPlane` dedups consecutive output vertices (a polygon crossing a clip plane through one of its own vertices - e.g. the frustum apex - emitted that vertex twice), (2) the wholly-outside fast path is now the exact face-vs-region intersection test (the "all vertices beyond the SAME plane" check missed faces straddling several infinite tilted planes, causing needless BSP fragmentation). Suite now 97 tests incl. `bottomCutout.test.ts` (synthetic + real-cell frustum sweep, width-1.0 tangency, 8-sided parameterization, plug).
+  - KNOWN ISSUE: the bottom cutout sometimes leaves very small leftover chunks - cells mostly consumed by the frustum survive as tiny fragments (watertight, but useless/fragile to print and they fall loose). Candidate fix: min-volume (or min-thickness) filter in `prepareForPrint` that drops cells below a threshold after cutting.
 - Next, on separate branches:
   - Improve distribution algorithm and explore restrictions for better bottom cutout separation (see "Point distribution" above - goal is a consistent, minimally-intersected bottom cell).
   - Gap-creation algorithm optimization.
+  - Bottom-cutout small-chunk filter (see KNOWN ISSUE above).
   - Inner-cube-cut optimization (second pass): performance (main-thread at download time; worker offload; live cut preview), fragmentation (subtractCubeFromFace recursion can over-fragment multi-plane faces), STL export memory (data-URL buildup in downloadButton).
   - Repo layout / overall refactor (known duplication between printCutting.ts and cellCuttingAlgorithm.ts helpers: plane math, vertex pool, sorting).
   - UI upgrade.

--- a/src/components/settings/downloadButton.tsx
+++ b/src/components/settings/downloadButton.tsx
@@ -3,6 +3,7 @@ import { BufferAttribute, BufferGeometry, Group, Mesh, MeshBasicMaterial } from 
 import { STLExporter } from 'three/examples/jsm/exporters/STLExporter';
 import { useVoronoiStore } from '../../store/store';
 import { prepareForPrint } from '../../utils/printCutting';
+import { buildBottomPlug } from '../../utils/plugGeometry';
 import { triangulateCellData } from '../../utils/cellCuttingAlgorithm';
 
 const download = (filename: string, text: string) => {
@@ -22,6 +23,10 @@ export const DownloadButton = () => {
   const cubeSize = useVoronoiStore(s => s.pointDistribution.size);
   const innerCubeSize = useVoronoiStore(s => s.innerCubeSize);
   const cutCells = useVoronoiStore(s => s.cutCells);
+  const cutInnerCube = useVoronoiStore(s => s.cutInnerCube);
+  const cutBottomHole = useVoronoiStore(s => s.cutBottomHole);
+  const bottomCutoutWidth = useVoronoiStore(s => s.bottomCutoutWidth);
+  const gapSize = useVoronoiStore(s => s.gapSize);
 
   const downloadVoronoi = useCallback(() => {
     const cellArray = Array.from(cutCells.values());
@@ -32,7 +37,17 @@ export const DownloadButton = () => {
 
     console.log(`Processing ${cellArray.length} cells for download...`);
 
-    const printCells = prepareForPrint(cellArray, cubeSize, innerCubeSize);
+    const printCells = prepareForPrint(cellArray, cubeSize, innerCubeSize, {
+      cutInnerCube,
+      cutBottomHole,
+      bottomCutoutWidth,
+    });
+
+    // In-place plug for the bottom cutout, so a full cube can be printed.
+    if (cutBottomHole) {
+      const plug = buildBottomPlug(cubeSize, innerCubeSize, bottomCutoutWidth, gapSize);
+      if (plug.faces.length > 0) printCells.push(plug);
+    }
 
     const group = new Group();
     const material = new MeshBasicMaterial();
@@ -58,7 +73,7 @@ export const DownloadButton = () => {
     download('voronoi.stl', data);
 
     console.log('Download complete');
-  }, [cubeSize, innerCubeSize, cutCells]);
+  }, [cubeSize, innerCubeSize, cutCells, cutInnerCube, cutBottomHole, bottomCutoutWidth, gapSize]);
 
   return <button onClick={() => downloadVoronoi()}>Download</button>;
 };

--- a/src/components/settings/downloadButton.tsx
+++ b/src/components/settings/downloadButton.tsx
@@ -26,6 +26,7 @@ export const DownloadButton = () => {
   const cutInnerCube = useVoronoiStore(s => s.cutInnerCube);
   const cutBottomHole = useVoronoiStore(s => s.cutBottomHole);
   const bottomCutoutWidth = useVoronoiStore(s => s.bottomCutoutWidth);
+  const bottomCutoutSides = useVoronoiStore(s => s.bottomCutoutSides);
   const gapSize = useVoronoiStore(s => s.gapSize);
 
   const downloadVoronoi = useCallback(() => {
@@ -41,11 +42,18 @@ export const DownloadButton = () => {
       cutInnerCube,
       cutBottomHole,
       bottomCutoutWidth,
+      bottomCutoutSides,
     });
 
     // In-place plug for the bottom cutout, so a full cube can be printed.
     if (cutBottomHole) {
-      const plug = buildBottomPlug(cubeSize, innerCubeSize, bottomCutoutWidth, gapSize);
+      const plug = buildBottomPlug(
+        cubeSize,
+        innerCubeSize,
+        bottomCutoutWidth,
+        gapSize,
+        bottomCutoutSides,
+      );
       if (plug.faces.length > 0) printCells.push(plug);
     }
 
@@ -73,7 +81,16 @@ export const DownloadButton = () => {
     download('voronoi.stl', data);
 
     console.log('Download complete');
-  }, [cubeSize, innerCubeSize, cutCells, cutInnerCube, cutBottomHole, bottomCutoutWidth, gapSize]);
+  }, [
+    cubeSize,
+    innerCubeSize,
+    cutCells,
+    cutInnerCube,
+    cutBottomHole,
+    bottomCutoutWidth,
+    bottomCutoutSides,
+    gapSize,
+  ]);
 
   return <button onClick={() => downloadVoronoi()}>Download</button>;
 };

--- a/src/components/settings/settings.tsx
+++ b/src/components/settings/settings.tsx
@@ -10,6 +10,12 @@ export const Settings = () => {
   const setPointDistribution = useVoronoiStore(state => state.setPointDistribution);
   const gapSize = useVoronoiStore(state => state.gapSize);
   const setGapSize = useVoronoiStore(state => state.setGapSize);
+  const cutInnerCube = useVoronoiStore(state => state.cutInnerCube);
+  const setCutInnerCube = useVoronoiStore(state => state.setCutInnerCube);
+  const cutBottomHole = useVoronoiStore(state => state.cutBottomHole);
+  const setCutBottomHole = useVoronoiStore(state => state.setCutBottomHole);
+  const bottomCutoutWidth = useVoronoiStore(state => state.bottomCutoutWidth);
+  const setBottomCutoutWidth = useVoronoiStore(state => state.setBottomCutoutWidth);
 
   const bufferTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -113,6 +119,43 @@ export const Settings = () => {
           />
         </div>
       </div>
+      <div className="preference">
+        <label htmlFor="cutInnerCube">Cut Inner Cube</label>
+        <input
+          id="cutInnerCube"
+          name="cutInnerCube"
+          type="checkbox"
+          checked={cutInnerCube}
+          onChange={e => setCutInnerCube(e.target.checked)}
+        />
+      </div>
+      <div className="preference">
+        <label htmlFor="cutBottomHole">Bottom Cutout</label>
+        <input
+          id="cutBottomHole"
+          name="cutBottomHole"
+          type="checkbox"
+          checked={cutBottomHole}
+          onChange={e => setCutBottomHole(e.target.checked)}
+        />
+      </div>
+      {cutBottomHole && (
+        <div className="preference">
+          <label htmlFor="bottomCutoutWidth">Cutout Width</label>
+          <div>
+            <input
+              id="bottomCutoutWidth"
+              name="bottomCutoutWidth"
+              type="range"
+              min={0.05}
+              max={1}
+              step={0.05}
+              value={bottomCutoutWidth}
+              onChange={e => setBottomCutoutWidth(Number.parseFloat(e.target.value))}
+            />
+          </div>
+        </div>
+      )}
       <div>
         <DownloadButton />
       </div>

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -58,7 +58,7 @@ export const useVoronoiStore = create<IVoronoiSettings>(set => {
     bottomCutoutWidth: 0.3,
     setBottomCutoutWidth: (bottomCutoutWidth: number) =>
       set({ bottomCutoutWidth: clamp(bottomCutoutWidth, 0.05, 1) }),
-    bottomCutoutSides: 6,
+    bottomCutoutSides: 8,
     setBottomCutoutSides: (bottomCutoutSides: number) =>
       set({ bottomCutoutSides: clamp(Math.round(bottomCutoutSides), 3, 16) }),
     darkMode: true,

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -55,7 +55,7 @@ export const useVoronoiStore = create<IVoronoiSettings>(set => {
     setCutInnerCube: (cutInnerCube: boolean) => set({ cutInnerCube }),
     cutBottomHole: true,
     setCutBottomHole: (cutBottomHole: boolean) => set({ cutBottomHole }),
-    bottomCutoutWidth: 0.3,
+    bottomCutoutWidth: 0.85,
     setBottomCutoutWidth: (bottomCutoutWidth: number) =>
       set({ bottomCutoutWidth: clamp(bottomCutoutWidth, 0.05, 1) }),
     bottomCutoutSides: 8,

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -21,6 +21,8 @@ interface IVoronoiSettings {
   setCutBottomHole: (cutBottomHole: boolean) => void;
   bottomCutoutWidth: number;
   setBottomCutoutWidth: (bottomCutoutWidth: number) => void;
+  bottomCutoutSides: number;
+  setBottomCutoutSides: (bottomCutoutSides: number) => void;
   darkMode: boolean;
   setDarkMode: (darkMode: boolean) => void;
   pointDistribution: IPointDistribution;
@@ -56,6 +58,9 @@ export const useVoronoiStore = create<IVoronoiSettings>(set => {
     bottomCutoutWidth: 0.3,
     setBottomCutoutWidth: (bottomCutoutWidth: number) =>
       set({ bottomCutoutWidth: clamp(bottomCutoutWidth, 0.05, 1) }),
+    bottomCutoutSides: 6,
+    setBottomCutoutSides: (bottomCutoutSides: number) =>
+      set({ bottomCutoutSides: clamp(Math.round(bottomCutoutSides), 3, 16) }),
     darkMode: true,
     setDarkMode: (darkMode: boolean) => set({ darkMode }),
     pointDistribution: {

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -15,6 +15,12 @@ interface IVoronoiSettings {
   debug: boolean;
   setDebug: (debug: boolean) => void;
   innerCubeSize: number;
+  cutInnerCube: boolean;
+  setCutInnerCube: (cutInnerCube: boolean) => void;
+  cutBottomHole: boolean;
+  setCutBottomHole: (cutBottomHole: boolean) => void;
+  bottomCutoutWidth: number;
+  setBottomCutoutWidth: (bottomCutoutWidth: number) => void;
   darkMode: boolean;
   setDarkMode: (darkMode: boolean) => void;
   pointDistribution: IPointDistribution;
@@ -43,6 +49,13 @@ export const useVoronoiStore = create<IVoronoiSettings>(set => {
     debug: false,
     setDebug: (debug: boolean) => set({ debug }),
     innerCubeSize: 0.85,
+    cutInnerCube: true,
+    setCutInnerCube: (cutInnerCube: boolean) => set({ cutInnerCube }),
+    cutBottomHole: true,
+    setCutBottomHole: (cutBottomHole: boolean) => set({ cutBottomHole }),
+    bottomCutoutWidth: 0.3,
+    setBottomCutoutWidth: (bottomCutoutWidth: number) =>
+      set({ bottomCutoutWidth: clamp(bottomCutoutWidth, 0.05, 1) }),
     darkMode: true,
     setDarkMode: (darkMode: boolean) => set({ darkMode }),
     pointDistribution: {

--- a/src/utils/plugGeometry.ts
+++ b/src/utils/plugGeometry.ts
@@ -1,14 +1,15 @@
 import { CutCellData } from '../workers/types/workerOutput';
 
 /**
- * Solid one-piece plug for the bottom hex-frustum cutout, so a full cube
+ * Solid one-piece plug for the bottom cutout (N-gon frustum), so a full cube
  * (no electronics feed-through) can be printed. World-positioned
  * (x/y/z offsets 0), faces wound outward (CCW viewed from outside) so
- * triangulateCellData derives correct normals.
+ * triangulateCellData derives correct normals. `sides` must match the
+ * cutout region's side count.
  *
  * Clearance: the hole walls cannot shrink (they are cap faces on the exact
  * frustum planes), so the plug takes the full `gapSize` - each side plane is
- * inset inward by gapSize along its normal. Because all six side planes pass
+ * inset inward by gapSize along its normal. Because all side planes pass
  * through the frustum apex (the cube center) and share the same normal
  * y-component by symmetry, insetting them is equivalent to translating the
  * apex down by gapSize / normalY; the plug is that translated pyramid,
@@ -19,15 +20,16 @@ export const buildBottomPlug = (
   innerCubeRatio: number,
   baseWidthRatio: number,
   gapSize: number,
+  sides = 6,
 ): CutCellData => {
   const half = cubeSize / 2;
   const innerHalf = (cubeSize * innerCubeRatio) / 2;
   const circumRadius = (baseWidthRatio * cubeSize) / 2;
 
-  // Outward side-plane normal y-component (same for all 6 sides): normal of
-  // the plane through the apex (origin) and base edge (corners k, k+1).
+  // Outward side-plane normal y-component (same for all sides): normal of
+  // the plane through the apex (origin) and base edge (corners 0, 1).
   const theta0 = 0;
-  const theta1 = Math.PI / 3;
+  const theta1 = (2 * Math.PI) / sides;
   const b0 = [circumRadius * Math.cos(theta0), -half, circumRadius * Math.sin(theta0)];
   const b1 = [circumRadius * Math.cos(theta1), -half, circumRadius * Math.sin(theta1)];
   const crossX = b0[1] * b1[2] - b0[2] * b1[1];
@@ -48,26 +50,25 @@ export const buildBottomPlug = (
   }
 
   const vertices: number[] = [];
-  // Bottom ring: indices 0..5, top ring: 6..11.
+  // Bottom ring: indices 0..sides-1, top ring: sides..2*sides-1.
   for (const [s, y] of [
     [sBottom, -half],
     [sTop, -innerHalf],
   ]) {
-    for (let k = 0; k < 6; k++) {
-      const theta = (k * Math.PI) / 3;
+    for (let k = 0; k < sides; k++) {
+      const theta = (k * 2 * Math.PI) / sides;
       vertices.push(s * circumRadius * Math.cos(theta), y, s * circumRadius * Math.sin(theta));
     }
   }
 
   // Winding: the bottom ring ordered by increasing theta winds with outward
   // (-y) normal, so it is the bottom cap directly; the top cap is reversed.
-  const faces: number[][] = [
-    [0, 1, 2, 3, 4, 5],
-    [11, 10, 9, 8, 7, 6],
-  ];
-  for (let k = 0; k < 6; k++) {
-    const k1 = (k + 1) % 6;
-    faces.push([k1, k, 6 + k, 6 + k1]);
+  const bottomCap = Array.from({ length: sides }, (_, k) => k);
+  const topCap = Array.from({ length: sides }, (_, k) => 2 * sides - 1 - k);
+  const faces: number[][] = [bottomCap, topCap];
+  for (let k = 0; k < sides; k++) {
+    const k1 = (k + 1) % sides;
+    faces.push([k1, k, sides + k, sides + k1]);
   }
 
   return { vertices, faces, particleId: -1, x: 0, y: 0, z: 0 };

--- a/src/utils/plugGeometry.ts
+++ b/src/utils/plugGeometry.ts
@@ -1,0 +1,74 @@
+import { CutCellData } from '../workers/types/workerOutput';
+
+/**
+ * Solid one-piece plug for the bottom hex-frustum cutout, so a full cube
+ * (no electronics feed-through) can be printed. World-positioned
+ * (x/y/z offsets 0), faces wound outward (CCW viewed from outside) so
+ * triangulateCellData derives correct normals.
+ *
+ * Clearance: the hole walls cannot shrink (they are cap faces on the exact
+ * frustum planes), so the plug takes the full `gapSize` - each side plane is
+ * inset inward by gapSize along its normal. Because all six side planes pass
+ * through the frustum apex (the cube center) and share the same normal
+ * y-component by symmetry, insetting them is equivalent to translating the
+ * apex down by gapSize / normalY; the plug is that translated pyramid,
+ * sliced between the cube bottom face and the inner-cavity floor.
+ */
+export const buildBottomPlug = (
+  cubeSize: number,
+  innerCubeRatio: number,
+  baseWidthRatio: number,
+  gapSize: number,
+): CutCellData => {
+  const half = cubeSize / 2;
+  const innerHalf = (cubeSize * innerCubeRatio) / 2;
+  const circumRadius = (baseWidthRatio * cubeSize) / 2;
+
+  // Outward side-plane normal y-component (same for all 6 sides): normal of
+  // the plane through the apex (origin) and base edge (corners k, k+1).
+  const theta0 = 0;
+  const theta1 = Math.PI / 3;
+  const b0 = [circumRadius * Math.cos(theta0), -half, circumRadius * Math.sin(theta0)];
+  const b1 = [circumRadius * Math.cos(theta1), -half, circumRadius * Math.sin(theta1)];
+  const crossX = b0[1] * b1[2] - b0[2] * b1[1];
+  const crossY = b0[2] * b1[0] - b0[0] * b1[2];
+  const crossZ = b0[0] * b1[1] - b0[1] * b1[0];
+  const crossLen = Math.hypot(crossX, crossY, crossZ);
+  const normalY = Math.abs(crossY) / crossLen;
+
+  // Translated apex; corner rays go from the apex through the original base
+  // corners' directions. At height y the ray parameter is (apexY - y) / half.
+  const apexY = -gapSize / normalY;
+  const sBottom = (apexY + half) / half;
+  const sTop = (apexY + innerHalf) / half;
+
+  if (sTop <= 0) {
+    // Gap so large the plug vanishes before reaching the cavity floor.
+    return { vertices: [], faces: [], particleId: -1, x: 0, y: 0, z: 0 };
+  }
+
+  const vertices: number[] = [];
+  // Bottom ring: indices 0..5, top ring: 6..11.
+  for (const [s, y] of [
+    [sBottom, -half],
+    [sTop, -innerHalf],
+  ]) {
+    for (let k = 0; k < 6; k++) {
+      const theta = (k * Math.PI) / 3;
+      vertices.push(s * circumRadius * Math.cos(theta), y, s * circumRadius * Math.sin(theta));
+    }
+  }
+
+  // Winding: the bottom ring ordered by increasing theta winds with outward
+  // (-y) normal, so it is the bottom cap directly; the top cap is reversed.
+  const faces: number[][] = [
+    [0, 1, 2, 3, 4, 5],
+    [11, 10, 9, 8, 7, 6],
+  ];
+  for (let k = 0; k < 6; k++) {
+    const k1 = (k + 1) % 6;
+    faces.push([k1, k, 6 + k, 6 + k1]);
+  }
+
+  return { vertices, faces, particleId: -1, x: 0, y: 0, z: 0 };
+};

--- a/src/utils/printCutting.ts
+++ b/src/utils/printCutting.ts
@@ -296,14 +296,14 @@ export const buildInnerCubeRegion = (
 // --- Build the bottom-cutout (hex frustum) cut region ------------------------
 
 /**
- * Hex frustum for the bottom electronics feed-through, in cell-local
- * coordinates. 6 side planes each contain the cube center and one edge of
- * the base hexagon on the cube bottom face (apex-at-center taper); the top
+ * N-gon frustum for the bottom electronics feed-through, in cell-local
+ * coordinates. `sides` side planes each contain the cube center and one edge
+ * of the base polygon on the cube bottom face (apex-at-center taper); the top
  * plane sits at the inner-cavity floor (y = -innerCubeHalf). The region is
  * unbounded below - the cell's own bottom face clip punches the base
- * hexagon hole. Plane order contract: 0..5 = sides, 6 = top.
+ * polygon hole. Plane order contract: 0..sides-1 = sides, sides = top.
  *
- * `baseWidthRatio` is the base hexagon's extent across corners
+ * `baseWidthRatio` is the base polygon's extent across corners
  * (2 * circumradius) as a fraction of cube size. `capTop` closes the top
  * with a cap (blind pocket, for cutting without the inner cavity); when the
  * inner cube is also cut, leave it open so the hole connects to the cavity.
@@ -316,28 +316,29 @@ export const buildBottomCutoutRegion = (
   cellX: number,
   cellY: number,
   cellZ: number,
+  sides = 6,
 ): CutRegion => {
   const half = cubeSize / 2;
   const innerHalf = (cubeSize * innerCubeRatio) / 2;
   const circumRadius = (baseWidthRatio * cubeSize) / 2;
   const cellPos = new Vector3(cellX, cellY, cellZ);
 
-  // Base hexagon corners on the cube bottom face (world coordinates).
+  // Base polygon corners on the cube bottom face (world coordinates).
   const baseCorners: Vector3[] = [];
-  for (let k = 0; k < 6; k++) {
-    const theta = (k * Math.PI) / 3;
+  for (let k = 0; k < sides; k++) {
+    const theta = (k * 2 * Math.PI) / sides;
     baseCorners.push(
       new Vector3(circumRadius * Math.cos(theta), -half, circumRadius * Math.sin(theta)),
     );
   }
 
   const planes: ClipPlane[] = [];
-  for (let k = 0; k < 6; k++) {
+  for (let k = 0; k < sides; k++) {
     // Side plane k through the cube center (world origin) and base edge
     // (corner k, corner k+1); world distance is therefore 0.
     const normal = baseCorners[k]
       .clone()
-      .cross(baseCorners[(k + 1) % 6])
+      .cross(baseCorners[(k + 1) % sides])
       .normalize();
     // Orient outward: the region interior (e.g. the base center (0,-half,0))
     // must satisfy normal . p <= 0, i.e. normal.y > 0.
@@ -349,17 +350,17 @@ export const buildBottomCutoutRegion = (
   const topNormal = new Vector3(0, 1, 0);
   planes.push({ normal: topNormal, distance: -innerHalf - topNormal.dot(cellPos) });
 
-  // Top hexagon corners: base corners scaled toward the apex (cube center)
+  // Top polygon corners: base corners scaled toward the apex (cube center)
   // onto the cavity floor. Corner k lies on side planes k-1 and k + the top.
   const scale = innerHalf / half;
   const corners: RegionCorner[] = baseCorners.map((base, k) => ({
     position: base.clone().multiplyScalar(scale).sub(cellPos),
-    planeIndices: [(k + 5) % 6, k, 6],
+    planeIndices: [(k + sides - 1) % sides, k, sides],
   }));
 
   return {
     planes,
-    capMask: [true, true, true, true, true, true, capTop],
+    capMask: [...Array<boolean>(sides).fill(true), capTop],
     corners,
   };
 };
@@ -775,7 +776,8 @@ export const cutInnerCubeFromCell = (
 export interface PrintPrepOptions {
   cutInnerCube?: boolean;
   cutBottomHole?: boolean;
-  bottomCutoutWidth?: number; // base hexagon width across corners, fraction of cube size
+  bottomCutoutWidth?: number; // base polygon width across corners, fraction of cube size
+  bottomCutoutSides?: number; // side count of the cutout polygon
 }
 
 /**
@@ -789,7 +791,12 @@ export const prepareForPrint = (
   innerCubeRatio: number,
   options: PrintPrepOptions = {},
 ): CutCellData[] => {
-  const { cutInnerCube = true, cutBottomHole = false, bottomCutoutWidth = 0.3 } = options;
+  const {
+    cutInnerCube = true,
+    cutBottomHole = false,
+    bottomCutoutWidth = 0.3,
+    bottomCutoutSides = 6,
+  } = options;
   const innerCubeHalfSize = (cubeSize * innerCubeRatio) / 2;
 
   return cells
@@ -806,6 +813,7 @@ export const prepareForPrint = (
           result.x,
           result.y,
           result.z,
+          bottomCutoutSides,
         );
         result = subtractRegionFromCell(result, region);
       }

--- a/src/utils/printCutting.ts
+++ b/src/utils/printCutting.ts
@@ -5,9 +5,29 @@ import { PLANE_TOL, ON_PLANE_TOL, KEY_PRECISION, EPSILON } from './geometryConst
 /**
  * A half-plane: normal . p <= distance defines the "inside".
  */
-interface ClipPlane {
+export interface ClipPlane {
   normal: Vector3;
   distance: number;
+}
+
+/** A vertex of a convex cut region, with the indices of the planes it lies on. */
+export interface RegionCorner {
+  position: Vector3;
+  planeIndices: number[];
+}
+
+/**
+ * A convex region to subtract from cells: intersection of half-spaces
+ * (normal . p <= distance is "inside"). `capMask[i]` controls whether cap
+ * faces are built on plane i (false = leave that boundary open, e.g. the
+ * frustum top opening into the inner cavity). `corners` are the region's
+ * vertices, used to seed cap polygons where a region corner lies inside a
+ * cell. All coordinates are CELL-LOCAL.
+ */
+export interface CutRegion {
+  planes: ClipPlane[];
+  capMask: boolean[];
+  corners: RegionCorner[];
 }
 
 // --- Polygon type used internally (arrays of Vector3) -----------------------
@@ -52,18 +72,34 @@ const clipPolygonByPlane = (polygon: Polygon, plane: ClipPlane): Polygon => {
     // Both outside -> skip
   }
 
-  return output;
+  // Drop consecutive (incl. wrap-around) duplicates: a vertex lying exactly
+  // ON the clip plane gets emitted twice - once by the "inside" case and
+  // once as the computed intersection point (t=0/t=1 lerp reproduces the
+  // endpoint). Happens whenever a polygon crosses the plane through one of
+  // its own vertices, e.g. a cell face passing through the frustum apex
+  // where all six side planes meet.
+  const deduped: Vector3[] = [];
+  for (const v of output) {
+    const prev = deduped[deduped.length - 1];
+    if (prev && prev.distanceTo(v) < EPSILON) continue;
+    deduped.push(v);
+  }
+  while (deduped.length > 1 && deduped[0].distanceTo(deduped[deduped.length - 1]) < EPSILON) {
+    deduped.pop();
+  }
+
+  return deduped;
 };
 
-// --- Recursive cube subtraction for a single face --------------------------
+// --- Recursive region subtraction for a single face --------------------------
 
 /**
- * Given a convex polygon (a cell face), subtract the inner cube defined by
- * `cubePlanes` (each plane's "inside" half-space; the cube interior is the
- * intersection of all six half-spaces).
+ * Given a convex polygon (a cell face), subtract the convex region defined by
+ * `cubePlanes` (each plane's "inside" half-space; the region interior is the
+ * intersection of all half-spaces).
  *
  * Returns an array of convex polygons that represent the parts of the face
- * that are OUTSIDE the inner cube.
+ * that are OUTSIDE the region.
  *
  * Algorithm (BSP-style recursive partition):
  *   For plane[0]:
@@ -215,15 +251,16 @@ const computeNewellNormal = (polygon: Polygon): Vector3 =>
 const computePolygonArea = (polygon: Polygon): number =>
   computeNewellNormalRaw(polygon).length() / 2;
 
-// --- Build 6 inner-cube clip planes (in cell-local coordinates) ------------
+// --- Build the inner-cube cut region (in cell-local coordinates) ------------
 
-const buildInnerCubePlanes = (
+export const buildInnerCubeRegion = (
   halfSize: number,
   cellX: number,
   cellY: number,
   cellZ: number,
-): ClipPlane[] => {
-  return [
+): CutRegion => {
+  // Plane indices: 0=+x, 1=-x, 2=+y, 3=-y, 4=+z, 5=-z
+  const planes: ClipPlane[] = [
     { normal: new Vector3(1, 0, 0), distance: halfSize - cellX },
     { normal: new Vector3(-1, 0, 0), distance: halfSize + cellX },
     { normal: new Vector3(0, 1, 0), distance: halfSize - cellY },
@@ -231,6 +268,100 @@ const buildInnerCubePlanes = (
     { normal: new Vector3(0, 0, 1), distance: halfSize - cellZ },
     { normal: new Vector3(0, 0, -1), distance: halfSize + cellZ },
   ];
+
+  // 8 cube corners, each on 3 planes.
+  const cornerPlaneSets: [number, number, number][] = [
+    [0, 2, 4],
+    [0, 2, 5],
+    [0, 3, 4],
+    [0, 3, 5],
+    [1, 2, 4],
+    [1, 2, 5],
+    [1, 3, 4],
+    [1, 3, 5],
+  ];
+
+  const corners: RegionCorner[] = cornerPlaneSets.map(([a, b, c]) => ({
+    position: new Vector3(
+      (a === 0 ? halfSize : -halfSize) - cellX,
+      (b === 2 ? halfSize : -halfSize) - cellY,
+      (c === 4 ? halfSize : -halfSize) - cellZ,
+    ),
+    planeIndices: [a, b, c],
+  }));
+
+  return { planes, capMask: planes.map(() => true), corners };
+};
+
+// --- Build the bottom-cutout (hex frustum) cut region ------------------------
+
+/**
+ * Hex frustum for the bottom electronics feed-through, in cell-local
+ * coordinates. 6 side planes each contain the cube center and one edge of
+ * the base hexagon on the cube bottom face (apex-at-center taper); the top
+ * plane sits at the inner-cavity floor (y = -innerCubeHalf). The region is
+ * unbounded below - the cell's own bottom face clip punches the base
+ * hexagon hole. Plane order contract: 0..5 = sides, 6 = top.
+ *
+ * `baseWidthRatio` is the base hexagon's extent across corners
+ * (2 * circumradius) as a fraction of cube size. `capTop` closes the top
+ * with a cap (blind pocket, for cutting without the inner cavity); when the
+ * inner cube is also cut, leave it open so the hole connects to the cavity.
+ */
+export const buildBottomCutoutRegion = (
+  cubeSize: number,
+  innerCubeRatio: number,
+  baseWidthRatio: number,
+  capTop: boolean,
+  cellX: number,
+  cellY: number,
+  cellZ: number,
+): CutRegion => {
+  const half = cubeSize / 2;
+  const innerHalf = (cubeSize * innerCubeRatio) / 2;
+  const circumRadius = (baseWidthRatio * cubeSize) / 2;
+  const cellPos = new Vector3(cellX, cellY, cellZ);
+
+  // Base hexagon corners on the cube bottom face (world coordinates).
+  const baseCorners: Vector3[] = [];
+  for (let k = 0; k < 6; k++) {
+    const theta = (k * Math.PI) / 3;
+    baseCorners.push(
+      new Vector3(circumRadius * Math.cos(theta), -half, circumRadius * Math.sin(theta)),
+    );
+  }
+
+  const planes: ClipPlane[] = [];
+  for (let k = 0; k < 6; k++) {
+    // Side plane k through the cube center (world origin) and base edge
+    // (corner k, corner k+1); world distance is therefore 0.
+    const normal = baseCorners[k]
+      .clone()
+      .cross(baseCorners[(k + 1) % 6])
+      .normalize();
+    // Orient outward: the region interior (e.g. the base center (0,-half,0))
+    // must satisfy normal . p <= 0, i.e. normal.y > 0.
+    if (normal.y < 0) normal.negate();
+    planes.push({ normal, distance: -normal.dot(cellPos) });
+  }
+
+  // Top plane: inside the region is y <= -innerHalf (below the cavity floor).
+  const topNormal = new Vector3(0, 1, 0);
+  planes.push({ normal: topNormal, distance: -innerHalf - topNormal.dot(cellPos) });
+
+  // Top hexagon corners: base corners scaled toward the apex (cube center)
+  // onto the cavity floor. Corner k lies on side planes k-1 and k + the top.
+  const scale = innerHalf / half;
+  const corners: RegionCorner[] = baseCorners.map((base, k) => ({
+    position: base.clone().multiplyScalar(scale).sub(cellPos),
+    planeIndices: [(k + 5) % 6, k, 6],
+  }));
+
+  return {
+    planes,
+    capMask: [true, true, true, true, true, true, capTop],
+    corners,
+  };
 };
 
 // --- Classify a point w.r.t. all cube planes -------------------------------
@@ -245,40 +376,45 @@ const isInsideCube = (point: Vector3, cubePlanes: ClipPlane[]): boolean => {
 // --- Build cap faces from new intersection vertices -------------------------
 
 /**
- * After clipping all faces, build cap faces on each inner-cube plane to close
- * the cell.  For each cube plane, collect all vertices that lie on it, sort
+ * After clipping all faces, build cap faces on each region plane to close
+ * the cell.  For each capped plane, collect all vertices that lie on it, sort
  * them into a polygon, and emit the face.
  *
- * We also check the 8 inner-cube corners — if a corner is inside the original
- * cell (satisfies all cell face planes), it becomes part of the cap face on
- * each of the 3 cube planes that meet at that corner.
+ * We also check the region's corners — if a corner is inside the cell
+ * (satisfies all cell face planes), it becomes part of the cap face on
+ * each of the region planes that meet at that corner. Corners on planes with
+ * capMask=false still feed adjacent capped planes' polygons (e.g. the frustum
+ * top-hexagon corners belong to the open top plane AND two capped side
+ * planes).
  */
 const buildCapFaces = (
   pool: VertexPool,
-  cubePlanes: ClipPlane[],
+  region: CutRegion,
   cellPlanes: ClipPlane[],
 ): number[][] => {
+  const { planes: cubePlanes, capMask, corners } = region;
+  const nPlanes = cubePlanes.length;
   const capFaces: number[][] = [];
 
-  // Pre-compute which vertices lie on which cube planes
+  // Pre-compute which vertices lie on which region planes
   const verticesOnPlane: Map<number, Set<number>> = new Map();
-  for (let pi = 0; pi < 6; pi++) verticesOnPlane.set(pi, new Set());
+  for (let pi = 0; pi < nPlanes; pi++) verticesOnPlane.set(pi, new Set());
 
   const nVerts = pool.vertices.length / 3;
   for (let vi = 0; vi < nVerts; vi++) {
     const v = pool.getVertex(vi);
-    for (let pi = 0; pi < 6; pi++) {
+    for (let pi = 0; pi < nPlanes; pi++) {
       const d = cubePlanes[pi].normal.dot(v) - cubePlanes[pi].distance;
       if (Math.abs(d) < ON_PLANE_TOL) {
         // A vertex on plane pi only belongs to that plane's cap if it also
-        // lies inside-or-on the cube w.r.t. every OTHER cube plane - i.e.
-        // within that face's square extent. Without this, a vertex created
+        // lies inside-or-on the region w.r.t. every OTHER region plane - i.e.
+        // within that face's extent. Without this, a vertex created
         // by clipping against an edge/corner-straddling cell face (which
         // lies on plane pi but beyond an adjacent plane) gets swept into
         // pi's cap polygon even though it belongs to kept solid geometry,
         // not the cavity boundary (D1).
         let withinFaceExtent = true;
-        for (let qi = 0; qi < 6; qi++) {
+        for (let qi = 0; qi < nPlanes; qi++) {
           if (qi === pi) continue;
           const dq = cubePlanes[qi].normal.dot(v) - cubePlanes[qi].distance;
           if (dq > ON_PLANE_TOL) {
@@ -293,44 +429,9 @@ const buildCapFaces = (
     }
   }
 
-  // Check inner-cube corners.  Each corner is the intersection of 3 axis-aligned planes.
-  // Plane indices: 0=+x, 1=-x, 2=+y, 3=-y, 4=+z, 5=-z
-  const cornerPlaneSets: [number, number, number][] = [
-    [0, 2, 4],
-    [0, 2, 5],
-    [0, 3, 4],
-    [0, 3, 5],
-    [1, 2, 4],
-    [1, 2, 5],
-    [1, 3, 4],
-    [1, 3, 5],
-  ];
-
-  for (const [a, b, c] of cornerPlaneSets) {
-    // Corner position: solve n_a . p = d_a, n_b . p = d_b, n_c . p = d_c
-    // Since normals are axis-aligned, this is trivial:
-    const corner = new Vector3();
-    // For plane with normal (+/-1,0,0): x = +/-distance
-    corner.x =
-      cubePlanes[a].normal.x !== 0
-        ? cubePlanes[a].distance * cubePlanes[a].normal.x
-        : cubePlanes[b].normal.x !== 0
-          ? cubePlanes[b].distance * cubePlanes[b].normal.x
-          : cubePlanes[c].distance * cubePlanes[c].normal.x;
-    corner.y =
-      cubePlanes[a].normal.y !== 0
-        ? cubePlanes[a].distance * cubePlanes[a].normal.y
-        : cubePlanes[b].normal.y !== 0
-          ? cubePlanes[b].distance * cubePlanes[b].normal.y
-          : cubePlanes[c].distance * cubePlanes[c].normal.y;
-    corner.z =
-      cubePlanes[a].normal.z !== 0
-        ? cubePlanes[a].distance * cubePlanes[a].normal.z
-        : cubePlanes[b].normal.z !== 0
-          ? cubePlanes[b].distance * cubePlanes[b].normal.z
-          : cubePlanes[c].distance * cubePlanes[c].normal.z;
-
-    // Check if corner is inside the cell
+  // Check region corners: a corner inside the cell seeds the cap polygons of
+  // every plane it lies on.
+  for (const { position: corner, planeIndices } of corners) {
     let insideCell = true;
     for (const cp of cellPlanes) {
       if (cp.normal.dot(corner) - cp.distance > PLANE_TOL) {
@@ -341,14 +442,15 @@ const buildCapFaces = (
 
     if (insideCell) {
       const vi = pool.getOrAdd(corner);
-      verticesOnPlane.get(a)!.add(vi);
-      verticesOnPlane.get(b)!.add(vi);
-      verticesOnPlane.get(c)!.add(vi);
+      for (const pi of planeIndices) {
+        verticesOnPlane.get(pi)!.add(vi);
+      }
     }
   }
 
-  // Build a cap face for each cube plane that has >= 3 vertices
-  for (let pi = 0; pi < 6; pi++) {
+  // Build a cap face for each capped region plane that has >= 3 vertices
+  for (let pi = 0; pi < nPlanes; pi++) {
+    if (!capMask[pi]) continue;
     const idxSet = verticesOnPlane.get(pi)!;
     if (idxSet.size < 3) continue;
 
@@ -560,14 +662,11 @@ const computeCellFacePlanes = (cellData: CutCellData): ClipPlane[] => {
 };
 
 /**
- * Cut the inner cube out of a single cell.
- * Returns a new CutCellData with the inner cube subtracted.
+ * Cut a convex region out of a single cell.
+ * Returns a new CutCellData with the region subtracted.
  */
-export const cutInnerCubeFromCell = (
-  cellData: CutCellData,
-  innerCubeHalfSize: number,
-): CutCellData => {
-  const cubePlanes = buildInnerCubePlanes(innerCubeHalfSize, cellData.x, cellData.y, cellData.z);
+export const subtractRegionFromCell = (cellData: CutCellData, region: CutRegion): CutCellData => {
+  const cubePlanes = region.planes;
 
   const pool = new VertexPool();
   const newFaces: number[][] = [];
@@ -582,29 +681,27 @@ export const cutInnerCubeFromCell = (
       idx => new Vector3(verts[idx * 3], verts[idx * 3 + 1], verts[idx * 3 + 2]),
     );
 
-    // Early return, "wholly outside" case (D6 root cause fix): the ORIGINAL
-    // check here was "every vertex is outside the cube" (i.e. each vertex
-    // fails *some* plane, possibly a *different* plane per vertex) - that is
-    // UNSOUND. "Outside a convex region" is not itself a convex condition:
-    // two vertices can each individually be outside the inner cube (via
-    // different faces of it) while the straight edge between them still
-    // dips through its interior - e.g. a face wrapping around a cube
-    // edge/corner, where the cube sits "between" two of its vertices. On
-    // real (non-axis-aligned) voronoi cells this silently kept such an edge
-    // whole instead of clipping it, leaving a hole where a neighboring
-    // face's matching clip expected the edge to be split - reproduced as a
-    // missing triangular cap face (checkCutCellData: a closed 3-cycle of
-    // unpaired directed edges) on realCell-n100-seed1-particle{87,90}.json.
+    // Early return, "wholly outside" case. History (D6): the ORIGINAL check
+    // was "every vertex is outside the region" (each vertex failing *some*
+    // plane, possibly a different one per vertex) - UNSOUND, since "outside
+    // a convex region" is not itself a convex condition (an edge between two
+    // outside vertices can still dip through the region's interior; see
+    // realCell-n100-seed1-particle{87,90}.json). The first fix required all
+    // vertices beyond the SAME plane - sound, but incomplete for regions
+    // with tilted planes (the hex frustum): a face can straddle several
+    // infinite side planes while the region itself (the intersection of ALL
+    // half-spaces) never touches it, and would get needlessly BSP-fragmented.
     //
-    // The SOUND version requires all vertices to be beyond the SAME plane:
-    // that IS a convex (half-space) condition, so if every vertex satisfies
-    // it, every point on every edge (and the whole polygon interior) does
-    // too - "outside" this single plane -> outside the cube.
-    const wholeFaceOutsideCube = cubePlanes.some(plane =>
-      polygon.every(v => plane.normal.dot(v) - plane.distance > PLANE_TOL),
-    );
-
-    if (wholeFaceOutsideCube) {
+    // The EXACT test: intersect the face with the region (Sutherland-Hodgman
+    // against every plane - exact for a convex polygon vs a convex region).
+    // If the intersection is empty or degenerate (below the area noise
+    // floor), the region removes nothing - keep the face unchanged.
+    let intersection: Polygon = polygon;
+    for (const plane of cubePlanes) {
+      intersection = clipPolygonByPlane(intersection, plane);
+      if (intersection.length < 3) break;
+    }
+    if (intersection.length < 3 || computePolygonArea(intersection) < EPSILON) {
       const faceIndices = polygon.map(v => pool.getOrAdd(v));
       newFaces.push(faceIndices);
       continue;
@@ -639,7 +736,7 @@ export const cutInnerCubeFromCell = (
 
   // Build cap faces to close the cell
   const cellPlanes = computeCellFacePlanes(cellData);
-  const capFaces = buildCapFaces(pool, cubePlanes, cellPlanes);
+  const capFaces = buildCapFaces(pool, region, cellPlanes);
   newFaces.push(...capFaces);
 
   // Edge-conformity pass: with all faces (including caps) present, splice
@@ -663,17 +760,56 @@ export const cutInnerCubeFromCell = (
 };
 
 /**
- * Process all cells: subtract the inner cube from each one.
- * Returns an array of CutCellData, one per cell, with the inner cube removed.
+ * Cut the inner cube out of a single cell.
+ * Returns a new CutCellData with the inner cube subtracted.
+ */
+export const cutInnerCubeFromCell = (
+  cellData: CutCellData,
+  innerCubeHalfSize: number,
+): CutCellData =>
+  subtractRegionFromCell(
+    cellData,
+    buildInnerCubeRegion(innerCubeHalfSize, cellData.x, cellData.y, cellData.z),
+  );
+
+export interface PrintPrepOptions {
+  cutInnerCube?: boolean;
+  cutBottomHole?: boolean;
+  bottomCutoutWidth?: number; // base hexagon width across corners, fraction of cube size
+}
+
+/**
+ * Process all cells: subtract the enabled print-prep regions from each one
+ * (inner cube first, then the bottom hex frustum). Defaults preserve the
+ * original inner-cube-only behavior.
  */
 export const prepareForPrint = (
   cells: CutCellData[],
   cubeSize: number,
   innerCubeRatio: number,
+  options: PrintPrepOptions = {},
 ): CutCellData[] => {
+  const { cutInnerCube = true, cutBottomHole = false, bottomCutoutWidth = 0.3 } = options;
   const innerCubeHalfSize = (cubeSize * innerCubeRatio) / 2;
 
   return cells
-    .map(cell => cutInnerCubeFromCell(cell, innerCubeHalfSize))
+    .map(cell => {
+      let result = cell;
+      if (cutInnerCube) result = cutInnerCubeFromCell(result, innerCubeHalfSize);
+      if (cutBottomHole) {
+        // Without the cavity the frustum top gets capped (blind pocket).
+        const region = buildBottomCutoutRegion(
+          cubeSize,
+          innerCubeRatio,
+          bottomCutoutWidth,
+          !cutInnerCube,
+          result.x,
+          result.y,
+          result.z,
+        );
+        result = subtractRegionFromCell(result, region);
+      }
+      return result;
+    })
     .filter(cell => cell.faces.length > 0);
 };

--- a/src/utils/tests/bottomCutout.test.ts
+++ b/src/utils/tests/bottomCutout.test.ts
@@ -1,0 +1,401 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import {
+  buildBottomCutoutRegion,
+  subtractRegionFromCell,
+  cutInnerCubeFromCell,
+  prepareForPrint,
+} from '../printCutting';
+import { buildBottomPlug } from '../plugGeometry';
+import { cutCellCore, triangulateCellData } from '../cellCuttingAlgorithm';
+import { polygonToTriangles } from '../geometryHelper';
+import { checkCutCellData, checkTriangulated, polygonVolume } from './helpers/meshInvariants';
+import { makeBoxCell } from './helpers/syntheticCells';
+import { generateRealCells } from './helpers/realCellFixtures';
+import type { CutCellData } from '../../workers/types/workerOutput';
+
+/**
+ * Bottom cutout (hex frustum) test suite.
+ *
+ * Frustum spec: 6 side planes each containing the cube center and one edge
+ * of the base hexagon (apex-at-center taper), one top plane at the inner-
+ * cavity floor (y = -innerCubeHalf). Region is unbounded below (the cell's
+ * own bottom face clip punches the base hexagon hole). Plane order contract:
+ * indices 0..5 = sides, index 6 = top. "Width" = hexagon extent across
+ * corners (2 * circumradius) as a fraction of cube size.
+ */
+
+// Cube of size 2 centered at origin: half = 1.
+const CUBE = 2;
+const HALF = CUBE / 2;
+const INNER_RATIO = 0.5; // innerCubeHalf = 0.5
+const INNER_HALF = (CUBE * INNER_RATIO) / 2;
+const BASE_W = 0.8; // base circumradius R = 0.8
+const R = (BASE_W * CUBE) / 2;
+
+const hexArea = (circumRadius: number): number =>
+  ((3 * Math.sqrt(3)) / 2) * circumRadius * circumRadius;
+
+// Hex pyramid with apex at the cube center: volume of the slice between the
+// cube bottom face (y=-HALF, hexagon circumradius R) and the cavity floor
+// (y=-INNER_HALF, circumradius scaled by INNER_HALF/HALF).
+const pyramidVol = (baseR: number, height: number): number => (hexArea(baseR) * height) / 3;
+const frustumVol =
+  pyramidVol(R, HALF) - pyramidVol(R * (INNER_HALF / HALF), INNER_HALF);
+
+const WHOLE_CUBE: [number, number, number] = [-1, -1, -1];
+const WHOLE_CUBE_MAX: [number, number, number] = [1, 1, 1];
+
+const triangulateAndCheck = (result: CutCellData) => {
+  const tri = triangulateCellData(result);
+  return checkTriangulated({
+    positions: Array.from(tri.positions),
+    normals: Array.from(tri.normals),
+    indices: Array.from(tri.indices),
+  });
+};
+
+// --- Region construction ------------------------------------------------------
+
+describe('buildBottomCutoutRegion', () => {
+  const region = buildBottomCutoutRegion(CUBE, INNER_RATIO, BASE_W, false, 0, 0, 0);
+
+  it('has 7 planes (6 sides + top) with the contracted cap mask', () => {
+    expect(region.planes.length).toBe(7);
+    expect(region.capMask).toEqual([true, true, true, true, true, true, false]);
+  });
+
+  it('capTop=true caps the top plane', () => {
+    const capped = buildBottomCutoutRegion(CUBE, INNER_RATIO, BASE_W, true, 0, 0, 0);
+    expect(capped.capMask[6]).toBe(true);
+  });
+
+  it('has the 6 top-hexagon corners, each on 2 side planes + the top plane', () => {
+    expect(region.corners.length).toBe(6);
+    for (const corner of region.corners) {
+      expect(corner.planeIndices.length).toBe(3);
+      expect(corner.planeIndices).toContain(6);
+      // On each listed plane (within tolerance), inside all others.
+      for (let pi = 0; pi < region.planes.length; pi++) {
+        const d =
+          region.planes[pi].normal.dot(corner.position) - region.planes[pi].distance;
+        if (corner.planeIndices.includes(pi)) {
+          expect(Math.abs(d)).toBeLessThan(1e-9);
+        } else {
+          expect(d).toBeLessThan(1e-9);
+        }
+      }
+      // Top-hexagon geometry: at the cavity floor, scaled circumradius.
+      expect(corner.position.y).toBeCloseTo(-INNER_HALF, 9);
+      const radial = Math.hypot(corner.position.x, corner.position.z);
+      expect(radial).toBeCloseTo(R * (INNER_HALF / HALF), 9);
+    }
+  });
+
+  it('side planes pass through the cube center (apex-at-center taper)', () => {
+    for (let pi = 0; pi < 6; pi++) {
+      // Cell at origin: cube center is the local origin -> distance 0.
+      expect(region.planes[pi].distance).toBeCloseTo(0, 9);
+    }
+  });
+});
+
+// --- Whole-cube cell: inner cube + frustum (the real print pipeline) ---------
+
+describe('whole-cube cell: inner cube cut then frustum cut', () => {
+  const cutBoth = (): CutCellData => {
+    const cell = makeBoxCell(WHOLE_CUBE, WHOLE_CUBE_MAX);
+    const cavityCut = cutInnerCubeFromCell(cell, INNER_HALF);
+    const region = buildBottomCutoutRegion(
+      CUBE,
+      INNER_RATIO,
+      BASE_W,
+      false,
+      cavityCut.x,
+      cavityCut.y,
+      cavityCut.z,
+    );
+    return subtractRegionFromCell(cavityCut, region);
+  };
+
+  it('checkCutCellData reports zero violations', () => {
+    expect(checkCutCellData(cutBoth())).toEqual([]);
+  });
+
+  it('checkTriangulated reports zero violations', () => {
+    expect(triangulateAndCheck(cutBoth())).toEqual([]);
+  });
+
+  it('volume = cube - inner cube - frustum', () => {
+    const expected = 8 - Math.pow(2 * INNER_HALF, 3) - frustumVol;
+    expect(polygonVolume(cutBoth())).toBeCloseTo(expected, 6);
+  });
+});
+
+// --- Blind pocket: frustum cut without inner cube (capTop=true) --------------
+
+describe('blind pocket: frustum only, capped top', () => {
+  const cutPocket = (): CutCellData => {
+    const cell = makeBoxCell(WHOLE_CUBE, WHOLE_CUBE_MAX);
+    const region = buildBottomCutoutRegion(CUBE, INNER_RATIO, BASE_W, true, cell.x, cell.y, cell.z);
+    return subtractRegionFromCell(cell, region);
+  };
+
+  it('checkCutCellData reports zero violations', () => {
+    expect(checkCutCellData(cutPocket())).toEqual([]);
+  });
+
+  it('checkTriangulated reports zero violations', () => {
+    expect(triangulateAndCheck(cutPocket())).toEqual([]);
+  });
+
+  it('volume = cube - frustum', () => {
+    expect(polygonVolume(cutPocket())).toBeCloseTo(8 - frustumVol, 6);
+  });
+});
+
+// --- Two half cells: frustum axis on the shared x=0 plane --------------------
+// Hard straddle case: each half sees only part of the hexagon. Volume
+// conservation across the pair needs no per-piece analytic formula.
+
+describe('two half cells straddling the frustum', () => {
+  const halves = (): CutCellData[] => {
+    const left = makeBoxCell([-1, -1, -1], [0, 1, 1], 0);
+    const right = makeBoxCell([0, -1, -1], [1, 1, 1], 1);
+    return [left, right].map(cell => {
+      const region = buildBottomCutoutRegion(
+        CUBE,
+        INNER_RATIO,
+        BASE_W,
+        true,
+        cell.x,
+        cell.y,
+        cell.z,
+      );
+      return subtractRegionFromCell(cell, region);
+    });
+  };
+
+  it('both halves pass checkCutCellData and checkTriangulated', () => {
+    for (const half of halves()) {
+      expect(checkCutCellData(half)).toEqual([]);
+      expect(triangulateAndCheck(half)).toEqual([]);
+    }
+  });
+
+  it('summed volume = cube - frustum', () => {
+    const total = halves().reduce((sum, half) => sum + polygonVolume(half), 0);
+    expect(total).toBeCloseTo(8 - frustumVol, 6);
+  });
+});
+
+// --- Max width 1.0: base hexagon inscribed in the bottom face -----------------
+// Corners touch the bottom-face edge midpoints (point tangency); top hexagon
+// corners touch the cavity-floor square edges. Both cuts must stay watertight.
+
+describe('width 1.0 (hexagon inscribed in bottom face)', () => {
+  const MAX_W = 1.0;
+  const maxR = (MAX_W * CUBE) / 2;
+  const maxFrustumVol =
+    pyramidVol(maxR, HALF) - pyramidVol(maxR * (INNER_HALF / HALF), INNER_HALF);
+
+  it('inner cube + frustum: watertight, volume-correct', () => {
+    const cell = makeBoxCell(WHOLE_CUBE, WHOLE_CUBE_MAX);
+    const cavityCut = cutInnerCubeFromCell(cell, INNER_HALF);
+    const region = buildBottomCutoutRegion(
+      CUBE,
+      INNER_RATIO,
+      MAX_W,
+      false,
+      cavityCut.x,
+      cavityCut.y,
+      cavityCut.z,
+    );
+    const cut = subtractRegionFromCell(cavityCut, region);
+    expect(checkCutCellData(cut)).toEqual([]);
+    expect(triangulateAndCheck(cut)).toEqual([]);
+    expect(polygonVolume(cut)).toBeCloseTo(8 - 1 - maxFrustumVol, 6);
+  });
+
+  it('plug at width 1.0 stays valid', () => {
+    const plug = buildBottomPlug(CUBE, INNER_RATIO, MAX_W, 0.05);
+    expect(checkCutCellData(plug)).toEqual([]);
+    expect(triangulateAndCheck(plug)).toEqual([]);
+    expect(polygonVolume(plug)).toBeLessThan(maxFrustumVol);
+  });
+});
+
+// --- No spurious fragmentation of faces the frustum never touches ------------
+// The side planes are infinite, so a face can straddle several of them while
+// its intersection with the region is still empty (the region is only the
+// area inside ALL planes). Such faces must be kept whole, not BSP-fragmented.
+
+describe('faces not intersecting the frustum stay unfragmented', () => {
+  it('whole-cube blind pocket keeps each far face as a single quad', () => {
+    const cell = makeBoxCell(WHOLE_CUBE, WHOLE_CUBE_MAX);
+    const region = buildBottomCutoutRegion(CUBE, INNER_RATIO, BASE_W, true, cell.x, cell.y, cell.z);
+    const cut = subtractRegionFromCell(cell, region);
+
+    // The frustum (max radial extent R=0.8 at the bottom) never reaches the
+    // cube side faces or the top face - each must survive as ONE face (the
+    // edge-conformity pass may still splice collinear T-junction vertices
+    // from neighboring bottom-face fragments into its border, so the vertex
+    // count is not asserted).
+    const facesOnPlane = (axis: 0 | 1 | 2, value: number) =>
+      cut.faces.filter(face =>
+        face.every(vi => Math.abs(cut.vertices[vi * 3 + axis] - value) < 1e-9),
+      );
+
+    for (const [axis, value] of [
+      [0, 1],
+      [0, -1],
+      [1, 1],
+      [2, 1],
+      [2, -1],
+    ] as [0 | 1 | 2, number][]) {
+      const faces = facesOnPlane(axis, value);
+      expect(faces.length, `axis=${axis} value=${value}`).toBe(1);
+    }
+  });
+});
+
+// --- Cell away from the frustum: untouched -----------------------------------
+
+describe('cell not touching the frustum', () => {
+  it('geometry and volume unchanged', () => {
+    const cell = makeBoxCell([0.1, 0.2, 0.1], [0.9, 0.9, 0.9]);
+    const region = buildBottomCutoutRegion(CUBE, INNER_RATIO, BASE_W, true, cell.x, cell.y, cell.z);
+    const cut = subtractRegionFromCell(cell, region);
+    expect(checkCutCellData(cut)).toEqual([]);
+    expect(polygonVolume(cut)).toBeCloseTo(0.8 * 0.7 * 0.8, 9);
+  });
+});
+
+// --- prepareForPrint options ---------------------------------------------------
+
+describe('prepareForPrint options', () => {
+  const cell = () => makeBoxCell(WHOLE_CUBE, WHOLE_CUBE_MAX);
+
+  it('default options keep the existing inner-cube-only behavior', () => {
+    const [prepared] = prepareForPrint([cell()], CUBE, INNER_RATIO);
+    expect(polygonVolume(prepared)).toBeCloseTo(8 - 1, 6);
+  });
+
+  it('cutInnerCube + cutBottomHole applies both cuts', () => {
+    const [prepared] = prepareForPrint([cell()], CUBE, INNER_RATIO, {
+      cutInnerCube: true,
+      cutBottomHole: true,
+      bottomCutoutWidth: BASE_W,
+    });
+    expect(polygonVolume(prepared)).toBeCloseTo(8 - 1 - frustumVol, 6);
+    expect(checkCutCellData(prepared)).toEqual([]);
+    expect(triangulateAndCheck(prepared)).toEqual([]);
+  });
+
+  it('cutBottomHole without cutInnerCube produces the capped blind pocket', () => {
+    const [prepared] = prepareForPrint([cell()], CUBE, INNER_RATIO, {
+      cutInnerCube: false,
+      cutBottomHole: true,
+      bottomCutoutWidth: BASE_W,
+    });
+    expect(polygonVolume(prepared)).toBeCloseTo(8 - frustumVol, 6);
+    expect(checkCutCellData(prepared)).toEqual([]);
+  });
+
+  it('both cuts disabled returns cells unchanged', () => {
+    const [prepared] = prepareForPrint([cell()], CUBE, INNER_RATIO, {
+      cutInnerCube: false,
+      cutBottomHole: false,
+    });
+    expect(polygonVolume(prepared)).toBeCloseTo(8, 9);
+  });
+});
+
+// --- Plug ----------------------------------------------------------------------
+
+describe('buildBottomPlug', () => {
+  it('gap=0 plug exactly fills the frustum hole', () => {
+    const plug = buildBottomPlug(CUBE, INNER_RATIO, BASE_W, 0);
+    expect(plug.vertices.length / 3).toBe(12);
+    expect(plug.faces.length).toBe(8);
+    expect(checkCutCellData(plug)).toEqual([]);
+    expect(triangulateAndCheck(plug)).toEqual([]);
+    expect(polygonVolume(plug)).toBeCloseTo(frustumVol, 9);
+  });
+
+  it('gap>0 plug is strictly smaller and stays clear of the hole walls by the gap', () => {
+    const gap = 0.1;
+    const plug = buildBottomPlug(CUBE, INNER_RATIO, BASE_W, gap);
+    expect(checkCutCellData(plug)).toEqual([]);
+    expect(triangulateAndCheck(plug)).toEqual([]);
+    expect(polygonVolume(plug)).toBeLessThan(frustumVol);
+
+    // Every vertex clears each hole side plane by >= gap and stays within
+    // the vertical extent of the hole.
+    const hole = buildBottomCutoutRegion(CUBE, INNER_RATIO, BASE_W, false, 0, 0, 0);
+    const nVerts = plug.vertices.length / 3;
+    for (let vi = 0; vi < nVerts; vi++) {
+      const x = plug.vertices[vi * 3];
+      const y = plug.vertices[vi * 3 + 1];
+      const z = plug.vertices[vi * 3 + 2];
+      for (let pi = 0; pi < 6; pi++) {
+        const p = hole.planes[pi];
+        const d = p.normal.x * x + p.normal.y * y + p.normal.z * z - p.distance;
+        expect(d).toBeLessThanOrEqual(-gap + 1e-9);
+      }
+      expect(y).toBeGreaterThanOrEqual(-HALF - 1e-9);
+      expect(y).toBeLessThanOrEqual(-INNER_HALF + 1e-9);
+    }
+  });
+
+  it('plug is world-positioned (zero cell offset)', () => {
+    const plug = buildBottomPlug(CUBE, INNER_RATIO, BASE_W, 0.1);
+    expect(plug.x).toBe(0);
+    expect(plug.y).toBe(0);
+    expect(plug.z).toBe(0);
+  });
+});
+
+// --- Real voro3d cells: full pipeline with the frustum stage -----------------
+
+describe('real cells: gap cut -> inner cube -> frustum', () => {
+  const SIZE = 15;
+  const GAP_SIZE = 0.5;
+  const RATIO = 0.85;
+  const WIDTH = 0.3;
+
+  let gapCutCells: CutCellData[] = [];
+
+  beforeAll(async () => {
+    const cells = await generateRealCells(100, 1, SIZE);
+    gapCutCells = cells.map(cell => {
+      const triangleIndices = cell.faces.map(polygonToTriangles).flat().flat();
+      const cutCellData = cutCellCore(cell, triangleIndices, GAP_SIZE, SIZE);
+      cutCellData.particleId = cell.particleID;
+      return cutCellData;
+    });
+  }, 60000);
+
+  it.each([WIDTH, 1.0])('every prepared cell is watertight and volume-bounded (width=%s)', width => {
+    const prepared = prepareForPrint(gapCutCells, SIZE, RATIO, {
+      cutInnerCube: true,
+      cutBottomHole: true,
+      bottomCutoutWidth: width,
+    });
+    expect(prepared.length).toBeGreaterThan(0);
+
+    const originalById = new Map(gapCutCells.map(c => [c.particleId, c]));
+    for (const cell of prepared) {
+      const cellLabel = `width=${width} particleId=${cell.particleId}`;
+      const violations = checkCutCellData(cell);
+      expect(violations, `${cellLabel}: ${JSON.stringify(violations)}`).toEqual([]);
+      const triViolations = triangulateAndCheck(cell);
+      expect(triViolations, `${cellLabel}: ${JSON.stringify(triViolations)}`).toEqual([]);
+
+      const original = originalById.get(cell.particleId)!;
+      expect(polygonVolume(cell), cellLabel).toBeLessThanOrEqual(
+        polygonVolume(original) + 1e-4,
+      );
+      expect(polygonVolume(cell), cellLabel).toBeGreaterThanOrEqual(-1e-4);
+    }
+  });
+});

--- a/src/utils/tests/bottomCutout.test.ts
+++ b/src/utils/tests/bottomCutout.test.ts
@@ -188,6 +188,66 @@ describe('two half cells straddling the frustum', () => {
   });
 });
 
+// --- Parameterized side count -------------------------------------------------
+// General N-gon: area = (n/2) * r^2 * sin(2*pi/n); same apex-at-center frustum.
+
+describe('parameterized side count (8-sided cutout + plug)', () => {
+  const SIDES = 8;
+  const ngonArea = (n: number, r: number): number => (n / 2) * r * r * Math.sin((2 * Math.PI) / n);
+  const ngonPyramidVol = (n: number, baseR: number, height: number): number =>
+    (ngonArea(n, baseR) * height) / 3;
+  const octFrustumVol =
+    ngonPyramidVol(SIDES, R, HALF) - ngonPyramidVol(SIDES, R * (INNER_HALF / HALF), INNER_HALF);
+
+  it('region has n+1 planes, n corners, contracted cap mask', () => {
+    const region = buildBottomCutoutRegion(CUBE, INNER_RATIO, BASE_W, false, 0, 0, 0, SIDES);
+    expect(region.planes.length).toBe(SIDES + 1);
+    expect(region.capMask).toEqual([...Array(SIDES).fill(true), false]);
+    expect(region.corners.length).toBe(SIDES);
+    for (const corner of region.corners) {
+      expect(corner.planeIndices).toContain(SIDES);
+    }
+  });
+
+  it('whole-cube cell: inner cube + 8-sided frustum, watertight and volume-correct', () => {
+    const cell = makeBoxCell(WHOLE_CUBE, WHOLE_CUBE_MAX);
+    const cavityCut = cutInnerCubeFromCell(cell, INNER_HALF);
+    const region = buildBottomCutoutRegion(
+      CUBE,
+      INNER_RATIO,
+      BASE_W,
+      false,
+      cavityCut.x,
+      cavityCut.y,
+      cavityCut.z,
+      SIDES,
+    );
+    const cut = subtractRegionFromCell(cavityCut, region);
+    expect(checkCutCellData(cut)).toEqual([]);
+    expect(triangulateAndCheck(cut)).toEqual([]);
+    expect(polygonVolume(cut)).toBeCloseTo(8 - 1 - octFrustumVol, 6);
+  });
+
+  it('8-sided plug: 2n verts, n+2 faces, gap=0 exactly fills the hole', () => {
+    const plug = buildBottomPlug(CUBE, INNER_RATIO, BASE_W, 0, SIDES);
+    expect(plug.vertices.length / 3).toBe(2 * SIDES);
+    expect(plug.faces.length).toBe(SIDES + 2);
+    expect(checkCutCellData(plug)).toEqual([]);
+    expect(triangulateAndCheck(plug)).toEqual([]);
+    expect(polygonVolume(plug)).toBeCloseTo(octFrustumVol, 9);
+  });
+
+  it('prepareForPrint passes bottomCutoutSides through', () => {
+    const [prepared] = prepareForPrint([makeBoxCell(WHOLE_CUBE, WHOLE_CUBE_MAX)], CUBE, INNER_RATIO, {
+      cutInnerCube: true,
+      cutBottomHole: true,
+      bottomCutoutWidth: BASE_W,
+      bottomCutoutSides: SIDES,
+    });
+    expect(polygonVolume(prepared)).toBeCloseTo(8 - 1 - octFrustumVol, 6);
+  });
+});
+
 // --- Max width 1.0: base hexagon inscribed in the bottom face -----------------
 // Corners touch the bottom-face edge midpoints (point tangency); top hexagon
 // corners touch the cavity-floor square edges. Both cuts must stay watertight.


### PR DESCRIPTION
## What

Bottom electronics feed-through for the lamp, per roadmap item "Bottom cutout shape".

- **N-gon frustum cutout** (default hexagon, side count parameterized via store-only `bottomCutoutSides`, no UI): side planes through the cube center (apex-at-center taper), base polygon on the bottom face, top opening at the inner-cavity floor. Uniform shape regardless of seed. Open into the cavity, or capped blind pocket when the inner cube is not cut.
- **Toggles**: separate `cutInnerCube` / `cutBottomHole` checkboxes + `bottomCutoutWidth` slider (0.05-1.0, polygon width across corners as fraction of cube size; 1.0 = inscribed in the bottom face). Applied at STL download time.
- **Plug**: solid one-piece frustum inset by gap size, exported in place inside the combined STL so a full cube prints. Vanishes geometrically below ~0.1 width at default gap (documented behavior).

## How

`printCutting.ts` generalized to `CutRegion` (convex plane set + per-plane cap mask + region corners). Inner cube is now a region builder; `cutInnerCubeFromCell` is a thin wrapper - the existing 68-test suite passed the refactor unchanged.

Two robustness fixes found via TDD:
1. `clipPolygonByPlane` emitted a vertex twice when the polygon crosses the clip plane through one of its own vertices (cell face through the frustum apex, where all side planes meet) - consecutive/wrap dedup added.
2. The "all vertices beyond the SAME plane" wholly-outside fast path missed faces straddling several infinite tilted planes whose region intersection is empty, causing needless BSP fragmentation - replaced with the exact face-vs-region intersection-emptiness test.

## Testing

- Suite: 97 tests green (`bottomCutout.test.ts`: region construction, both-cut + blind-pocket volumes, straddle conservation, width-1.0 tangency, 8-sided parameterization, plug invariants + fit clearance, real voro3d cell sweep at widths 0.3 and 1.0).
- Verified in the running app via Playwright: download with cuts on/off, STL parsed - hole + plug present/absent as toggled, blind-pocket path correct.