### PR TITLE
fix: repair broken CI, add PR build check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - name: Set Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Test
+        run: pnpm test
+
+      - name: Build
+        run: pnpm build

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -29,14 +29,12 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: pnpm/action-setup@v2
-        with:
-          version: 9.14.2
+      - uses: pnpm/action-setup@v4
 
-      - name: Set Node.js 20.x 🔧
-        uses: actions/setup-node@v3
+      - name: Set Node.js 🔧
+        uses: actions/setup-node@v4
         with:
-          node-version: 20.x
+          node-version: 22.x
           cache: 'pnpm'
       - name: Install Dependencies 📦
         run: pnpm install --frozen-lockfile

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "version": "0.0.0",
   "type": "module",
+  "packageManager": "pnpm@11.13.1",
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,6 @@
+packages:
+  - '.'
+
 allowBuilds:
   '@parcel/watcher': true
   esbuild: true


### PR DESCRIPTION
## Summary
- pnpm-workspace.yaml was missing `packages`, which pnpm 9.14.2 (pinned in CI) errors on; pin pnpm via `packageManager` and add `packages` field. Bump Node 20 -> 22.
- Add `ci.yml`: runs test + build on pull_request (and push to main) so failures show before merge.

## Test plan
- [x] `pnpm install --frozen-lockfile`, `pnpm test`, `pnpm build` all pass locally
- [x] Reproduced original error with `npx pnpm@9.14.2 store path`, confirmed fixed after workspace change