### PR TITLE
fix: bottom-cutout plug color matches the cube

### DIFF
--- a/src/components/renderer/scene/bottomCutout.tsx
+++ b/src/components/renderer/scene/bottomCutout.tsx
@@ -38,7 +38,7 @@ export const BottomCutout = ({ size = 10 }: BottomCutoutProps) => {
 
   return (
     <mesh geometry={geometry}>
-      <meshStandardMaterial color="#ff8c00" />
+      <meshPhongMaterial color="#949494" flatShading />
     </mesh>
   );
 };


### PR DESCRIPTION
Follow-up to #19. The squash merge captured the pre-amend orange material for the bottom-cutout plug; this sets it to the cube cells' color (`meshPhongMaterial #949494 flatShading`) so the previewed plug blends in.